### PR TITLE
fix: overwrite option declaration of subcommand

### DIFF
--- a/src/leetcode-dump.ts
+++ b/src/leetcode-dump.ts
@@ -13,6 +13,7 @@ const package_meta = get_package_meta();
 program.version(chalk`{cyanBright ${package_meta.name}} {yellowBright v${package_meta.version}}`);
 
 program
+    .enablePositionalOptions()
     .option(
         "-s, --session <session>",
         "Your LeetCode Session",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,7 @@ export function ext_to_lang(ext: string): string {
 export class Logger {
     constructor(public name = "", public verbose = 3) {
         if (verbose) {
-            this.log(`Verbose Mode: ${verbose}`);
+            this.log(`Verbose Level: ${verbose}`);
         }
     }
 


### PR DESCRIPTION
`leetcode-dump build -s abc` now parses `-s` as `-s, --source`, not `-s, --session`.